### PR TITLE
Changelogs

### DIFF
--- a/fcs-aai/changelog.adoc
+++ b/fcs-aai/changelog.adoc
@@ -1,0 +1,23 @@
+= Changelog
+
+// tag::compact[]
+
+// --- Github ---
+
+[discrete]
+== 2023-06-12 -- Conversion to AsciiDoc and Migration of specification documents to Github
+// https://github.com/clarin-eric/fcs-misc/commit/5b8952c1bfe96495f70e866634bf5dcf17166ba3
+
+* Convert specification documents for FCS Core 2.0, Core 1.0, DataView and AAI to AsciiDoc
+* Migrate from CLARIN Trac to https://github.com/clarin-eric/[CLARIN Github]
+* Add Github Actions workflow to automate build process
+
+// --- versions in cloud.fripost.org ---
+
+[discrete]
+== 2021-01-27 -- FCS Update Proposal for AAI
+// https://cloud.fripost.org/s/K49go8pARLEA5tY?dir=undefined&openfile=1946589
+
+[discrete]
+== 2020-02-19 -- Meeting about Shibbolizing FCS
+// https://cloud.fripost.org/s/K49go8pARLEA5tY?dir=undefined&openfile=871637

--- a/fcs-aai/index.adoc
+++ b/fcs-aai/index.adoc
@@ -40,3 +40,7 @@ include::introduction.adoc[leveloffset=+1]
 
 include::implementation.adoc[leveloffset=+1]
 
+<<<
+
+:sectnums!:
+include::changelog.adoc[leveloffset=+1]

--- a/fcs-core-1.0/changelog.adoc
+++ b/fcs-core-1.0/changelog.adoc
@@ -1,0 +1,28 @@
+= Changelog
+
+// tag::compact[]
+
+// --- Github ---
+
+[discrete]
+== 2023-06-12 -- Conversion to AsciiDoc and Migration of specification documents to Github
+// https://github.com/clarin-eric/fcs-misc/commit/5b8952c1bfe96495f70e866634bf5dcf17166ba3
+
+* Convert specification documents for FCS Core 2.0, Core 1.0, DataView and AAI to AsciiDoc
+* Migrate from CLARIN Trac to https://github.com/clarin-eric/[CLARIN Github]
+* Add Github Actions workflow to automate build process
+
+// --- versions in Trac ---
+
+[discrete]
+== 2018-09-06 -- Last version on Trac
+// https://trac.clarin.eu/wiki/FCS/Specification?version=6
+// https://trac.clarin.eu/wiki/FCS/Specification?action=diff&version=6&old_version=1
+
+* Proofing, typo fixes, updated links
+
+[discrete]
+== 2014-05-05 -- Data Views specification
+// https://trac.clarin.eu/wiki/FCS/Specification?version=1
+
+* Add full FCS Core 1.0 specification

--- a/fcs-core-1.0/index.adoc
+++ b/fcs-core-1.0/index.adoc
@@ -51,3 +51,8 @@ include::normative-appendix.adoc[leveloffset=+1]
 
 [appendix]
 include::non-normative-appendix.adoc[leveloffset=+1]
+
+<<<
+
+:sectnums!:
+include::changelog.adoc[leveloffset=+1]

--- a/fcs-core-2.0/changelog.adoc
+++ b/fcs-core-2.0/changelog.adoc
@@ -1,0 +1,59 @@
+= Changelog
+
+:sectnums!:
+
+// tag::compact[]
+
+// --- Github ---
+
+== 2024-04-10 -- Static Github Pages with builds from specification sources
+// https://github.com/clarin-eric/fcs-misc/commit/c1a01f0515216508262010347573d69e4a41aafb
+// https://github.com/clarin-eric/fcs-misc/commit/10100e687fb4a601b565166085a6803ddce45f0e
+
+* Webpage: https://clarin-eric.github.io/fcs-misc/
+
+== 2023-06-29 -- Fix Typo
+// https://github.com/clarin-eric/fcs-misc/commit/dbc795dc5cc1a6e7ecc52bda3fcaa1fdefeccc48
+
+== 2023-06-12 -- Conversion to AsciiDoc and Migration of specification documents to Github
+// https://github.com/clarin-eric/fcs-misc/commit/5b8952c1bfe96495f70e866634bf5dcf17166ba3
+
+* Convert specification documents for FCS Core 2.0, Core 1.0, DataView and AAI to AsciiDoc
+* Migrate from CLARIN Trac to https://github.com/clarin-eric/[CLARIN Github]
+* Add Github Actions workflow to automate build process
+
+// --- versions in Trac ---
+
+== 2022-08-03 -- Final version on Trac
+// https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?version=89
+// https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?action=diff&version=89&old_version=82
+// https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?action=history
+
+* Fixes of typos, broken references, EBNF
+* Reformatting XML examples
+* Update Advanced Data View example, Segment end index is inclusive
+
+== 2018-12-04 -- SCCTC approved specification
+// https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?version=82
+// https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?action=diff&version=82&old_version=74
+
+* Reformatting
+* Proofing, update language and examples
+
+== 2017-06-16 -- Specification candidate for approval by SCCTC
+// https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?version=74
+// https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?action=diff&version=74&old_version=50
+// https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?version=51
+// https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?action=diff&version=51&old_version=50
+
+* Proofing, reformulations
+* Add SRU 2.0 examples
+
+== 2017-04-03 -- Final editing phase of draft
+// https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?version=50
+// https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?action=diff&version=50&old_version=1
+
+== 2015-10-15 -- Start with Core 2.0 specification
+// https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?version=1
+
+:sectnums:

--- a/fcs-core-2.0/changelog.adoc
+++ b/fcs-core-2.0/changelog.adoc
@@ -6,15 +6,18 @@
 
 // --- Github ---
 
+[discrete]
 == 2024-04-10 -- Static Github Pages with builds from specification sources
 // https://github.com/clarin-eric/fcs-misc/commit/c1a01f0515216508262010347573d69e4a41aafb
 // https://github.com/clarin-eric/fcs-misc/commit/10100e687fb4a601b565166085a6803ddce45f0e
 
 * Webpage: https://clarin-eric.github.io/fcs-misc/
 
+[discrete]
 == 2023-06-29 -- Fix Typo
 // https://github.com/clarin-eric/fcs-misc/commit/dbc795dc5cc1a6e7ecc52bda3fcaa1fdefeccc48
 
+[discrete]
 == 2023-06-12 -- Conversion to AsciiDoc and Migration of specification documents to Github
 // https://github.com/clarin-eric/fcs-misc/commit/5b8952c1bfe96495f70e866634bf5dcf17166ba3
 
@@ -24,6 +27,7 @@
 
 // --- versions in Trac ---
 
+[discrete]
 == 2022-08-03 -- Final version on Trac
 // https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?version=89
 // https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?action=diff&version=89&old_version=82
@@ -33,6 +37,7 @@
 * Reformatting XML examples
 * Update Advanced Data View example, Segment end index is inclusive
 
+[discrete]
 == 2018-12-04 -- SCCTC approved specification
 // https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?version=82
 // https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?action=diff&version=82&old_version=74
@@ -40,6 +45,7 @@
 * Reformatting
 * Proofing, update language and examples
 
+[discrete]
 == 2017-06-16 -- Specification candidate for approval by SCCTC
 // https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?version=74
 // https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?action=diff&version=74&old_version=50
@@ -49,10 +55,12 @@
 * Proofing, reformulations
 * Add SRU 2.0 examples
 
+[discrete]
 == 2017-04-03 -- Final editing phase of draft
 // https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?version=50
 // https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?action=diff&version=50&old_version=1
 
+[discrete]
 == 2015-10-15 -- Start with Core 2.0 specification
 // https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?version=1
 

--- a/fcs-core-2.0/changelog.adoc
+++ b/fcs-core-2.0/changelog.adoc
@@ -1,7 +1,5 @@
 = Changelog
 
-:sectnums!:
-
 // tag::compact[]
 
 // --- Github ---
@@ -63,5 +61,3 @@
 [discrete]
 == 2015-10-15 -- Start with Core 2.0 specification
 // https://trac.clarin.eu/wiki/Taskforces/FCS/FCS-Specification-Draft?version=1
-
-:sectnums:

--- a/fcs-core-2.0/index.adoc
+++ b/fcs-core-2.0/index.adoc
@@ -51,3 +51,7 @@ include::normative-appendix.adoc[leveloffset=+1]
 
 [appendix]
 include::non-normative-appendix.adoc[leveloffset=+1]
+
+<<<
+
+include::changelog.adoc[leveloffset=+1]

--- a/fcs-core-2.0/index.adoc
+++ b/fcs-core-2.0/index.adoc
@@ -54,4 +54,5 @@ include::non-normative-appendix.adoc[leveloffset=+1]
 
 <<<
 
+:sectnums!:
 include::changelog.adoc[leveloffset=+1]

--- a/fcs-dataviews-1.0/changelog.adoc
+++ b/fcs-dataviews-1.0/changelog.adoc
@@ -1,0 +1,32 @@
+= Changelog
+
+:sectnums!:
+
+// tag::compact[]
+
+// --- Github ---
+
+[discrete]
+== 2023-06-12 -- Conversion to AsciiDoc and Migration of specification documents to Github
+// https://github.com/clarin-eric/fcs-misc/commit/5b8952c1bfe96495f70e866634bf5dcf17166ba3
+
+* Convert specification documents for FCS Core 2.0, Core 1.0, DataView and AAI to AsciiDoc
+* Migrate from CLARIN Trac to https://github.com/clarin-eric/[CLARIN Github]
+* Add Github Actions workflow to automate build process
+
+// --- versions in Trac ---
+
+[discrete]
+== 2017-06-13 -- Last version on Trac
+// https://trac.clarin.eu/wiki/FCS/Dataviews?version=6
+// https://trac.clarin.eu/wiki/FCS/Dataviews?action=diff&version=6&old_version=1
+
+* Proofing, typo fixes, updated links
+
+[discrete]
+== 2014-05-05 -- Data Views specification
+// https://trac.clarin.eu/wiki/FCS/Dataviews?version=1
+
+* Add full specification
+
+:sectnums:

--- a/fcs-dataviews-1.0/changelog.adoc
+++ b/fcs-dataviews-1.0/changelog.adoc
@@ -1,7 +1,5 @@
 = Changelog
 
-:sectnums!:
-
 // tag::compact[]
 
 // --- Github ---
@@ -28,5 +26,3 @@
 // https://trac.clarin.eu/wiki/FCS/Dataviews?version=1
 
 * Add full specification
-
-:sectnums:

--- a/fcs-dataviews-1.0/index.adoc
+++ b/fcs-dataviews-1.0/index.adoc
@@ -39,3 +39,7 @@ include::introduction.adoc[leveloffset=+1]
 <<<
 
 include::dataviews.adoc[leveloffset=+1]
+
+<<<
+
+include::changelog.adoc[leveloffset=+1]

--- a/fcs-dataviews-1.0/index.adoc
+++ b/fcs-dataviews-1.0/index.adoc
@@ -42,4 +42,5 @@ include::dataviews.adoc[leveloffset=+1]
 
 <<<
 
+:sectnums!:
 include::changelog.adoc[leveloffset=+1]


### PR DESCRIPTION
Add changelogs for FCS specification documents.

Only brief changelog history of older CLARIN Trac versions with main events as far as I could see.